### PR TITLE
feat: log completion of the whole batch

### DIFF
--- a/main.go
+++ b/main.go
@@ -136,6 +136,8 @@ func main() { // nolint: cyclop, funlen
 		log.Errorf("failed to exec on all the allocations: %v", err)
 	}
 
+	log.Infof("command `%s` ran successfully on %d allocations with concurrency %d.", *cmd, nbAllocs, concurrency)
+
 	close(execOutputCh)
 
 	<-done


### PR DESCRIPTION
This makes it easier to see if the whole nomad-job-exec command
completed, or if commands are still running.