### PR TITLE
fix: exit with non-0 if no allocations were found

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,9 +75,7 @@ func main() { // nolint: cyclop, funlen
 
 	nbAllocs := len(allocationsInfo)
 	if nbAllocs == 0 {
-		log.Infof("no allocations found for job %q", *jobID)
-
-		os.Exit(0)
+		log.Fatalf("no allocations found for job %q", *jobID)
 	}
 
 	logger := log.WithFields(log.Fields{


### PR DESCRIPTION
If we request to execute a command against something and we don't find
any place to execute, it's most probably an error: wrong job name, wrong
task name, etc.