### PR TITLE
fix(goreleaser): rm-dist has been deprecated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,6 @@ jobs:
       - name: Release
         uses: goreleaser/goreleaser-action@v6.2.1
         with:
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
in favor of --clean https://goreleaser.com/deprecations/#-rm-dist